### PR TITLE
Migrate from jsonpath to jsonpath-plus

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,16 +10,37 @@
 			"license": "MIT",
 			"dependencies": {
 				"fast-json-patch": "^3.1.1",
-				"jsonpath": "^1.1.1"
+				"jsonpath-plus": "^10.4.0"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.4",
-				"@types/jsonpath": "^0.2.0",
 				"@types/mocha": "^10.0.1",
 				"chai": "^4.3.7",
 				"mocha": "^10.2.0",
 				"ts-mocha": "^10.0.0",
 				"typescript": "^4.9.5"
+			}
+		},
+		"node_modules/@jsep-plugin/assignment": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+			"integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+			"engines": {
+				"node": ">= 10.16.0"
+			},
+			"peerDependencies": {
+				"jsep": "^0.4.0||^1.0.0"
+			}
+		},
+		"node_modules/@jsep-plugin/regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+			"integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+			"engines": {
+				"node": ">= 10.16.0"
+			},
+			"peerDependencies": {
+				"jsep": "^0.4.0||^1.0.0"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -34,12 +55,6 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true,
 			"optional": true
-		},
-		"node_modules/@types/jsonpath": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@types/jsonpath/-/jsonpath-0.2.0.tgz",
-			"integrity": "sha512-v7qlPA0VpKUlEdhghbDqRoKMxFB3h3Ch688TApBJ6v+XLDdvWCGLJIYiPKGZnS6MAOie+IorCfNYVHOPIHSWwQ==",
-			"dev": true
 		},
 		"node_modules/@types/mocha": {
 			"version": "10.0.1",
@@ -342,11 +357,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/deep-is": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
-		},
 		"node_modules/diff": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -383,76 +393,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/escodegen": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=4.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/esprima": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-			"integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/fast-json-patch": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
 			"integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
-		},
-		"node_modules/fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
@@ -703,6 +647,14 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsep": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+			"engines": {
+				"node": ">= 10.16.0"
+			}
+		},
 		"node_modules/json5": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -716,26 +668,21 @@
 				"json5": "lib/cli.js"
 			}
 		},
-		"node_modules/jsonpath": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-			"integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
+		"node_modules/jsonpath-plus": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+			"integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
 			"dependencies": {
-				"esprima": "1.2.2",
-				"static-eval": "2.0.2",
-				"underscore": "1.12.1"
-			}
-		},
-		"node_modules/levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-			"dependencies": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"@jsep-plugin/assignment": "^1.3.0",
+				"@jsep-plugin/regex": "^1.0.4",
+				"jsep": "^1.4.0"
+			},
+			"bin": {
+				"jsonpath": "bin/jsonpath-cli.js",
+				"jsonpath-plus": "bin/jsonpath-cli.js"
 			},
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/locate-path": {
@@ -893,22 +840,6 @@
 				"wrappy": "1"
 			}
 		},
-		"node_modules/optionator": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"dependencies": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.6",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"word-wrap": "~1.2.3"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -978,14 +909,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1049,7 +972,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"devOptional": true,
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1062,14 +985,6 @@
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/static-eval": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-			"integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-			"dependencies": {
-				"escodegen": "^1.8.1"
 			}
 		},
 		"node_modules/string-width": {
@@ -1213,17 +1128,6 @@
 				"strip-bom": "^3.0.0"
 			}
 		},
-		"node_modules/type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-			"dependencies": {
-				"prelude-ls": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -1244,19 +1148,6 @@
 			},
 			"engines": {
 				"node": ">=4.2.0"
-			}
-		},
-		"node_modules/underscore": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-			"integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
-		},
-		"node_modules/word-wrap": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-			"integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/workerpool": {

--- a/js/package.json
+++ b/js/package.json
@@ -29,11 +29,10 @@
 	},
 	"dependencies": {
 		"fast-json-patch": "^3.1.1",
-		"jsonpath": "^1.1.1"
+		"jsonpath-plus": "^10.4.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.3.4",
-		"@types/jsonpath": "^0.2.0",
 		"@types/mocha": "^10.0.1",
 		"chai": "^4.3.7",
 		"mocha": "^10.2.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "object-basin",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "JavaScript/TypeScript library to stream updates to an object.",
 	"license": "MIT",
 	"repository": {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,5 +1,5 @@
 import jsonpatch, { Operation } from 'fast-json-patch'
-import jp from 'jsonpath'
+import { JSONPath } from 'jsonpath-plus'
 
 // Export to help dependencies because this is used in our interface.
 export { Operation } from 'fast-json-patch'
@@ -101,10 +101,14 @@ export class Basin<T> {
 			delete cursor.d
 		}
 
-		const expressions = jp.parse(cursor.jsonPath!)
-		for (const expression of expressions) {
-			if (expression.expression.type !== 'root') {
-				this._keys.set(label, expression.expression.value)
+		if (!cursor.jsonPath!.startsWith('$')) {
+		 	cursor.jsonPath = '$.' + cursor.jsonPath
+		}
+
+		const pathArray = JSONPath.toPathArray(cursor.jsonPath!)
+		for (const segment of pathArray) {
+			if (segment !== '$') {
+				this._keys.set(label, segment)
 				break
 			}
 		}
@@ -123,9 +127,9 @@ export class Basin<T> {
 		const jsonPath = cursor.jsonPath!
 		if (typeof position !== 'number') {
 			// Set the value.
-			jp.value(this.items, jsonPath, value)
+			jpValue(this.items, jsonPath, value)
 		} else {
-			jp.apply(this.items, jsonPath, (currentValue: string) => {
+			jpApply(this.items, jsonPath, (currentValue: string) => {
 				if (Array.isArray(currentValue)) {
 					if (cursor.deleteCount !== undefined) {
 						// Delete
@@ -155,5 +159,33 @@ export class Basin<T> {
 
 		const key = this._keys.get(cursorLabel)!
 		return this.items[key]
+	}
+}
+
+function jpValue(obj: any, path: string, value: any): void {
+	const results: any[] = JSONPath({ path, json: obj, resultType: 'all' })
+	if (results.length > 0) {
+		results[0].parent[results[0].parentProperty] = value
+	} else {
+		// Path doesn't exist yet — create intermediate objects and set the value.
+		const pathArray = JSONPath.toPathArray(path)
+		let current = obj
+		for (let i = 1; i < pathArray.length - 1; i++) {
+			const key = pathArray[i]
+			if (current[key] === undefined) {
+				current[key] = {}
+			}
+			current = current[key]
+		}
+		if (pathArray.length > 1) {
+			current[pathArray[pathArray.length - 1]] = value
+		}
+	}
+}
+
+function jpApply(obj: any, path: string, fn: (value: any) => any): void {
+	const results: any[] = JSONPath({ path, json: obj, resultType: 'all' })
+	for (const result of results) {
+		result.parent[result.parentProperty] = fn(result.value)
 	}
 }

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -102,16 +102,11 @@ export class Basin<T> {
 		}
 
 		if (!cursor.jsonPath!.startsWith('$')) {
-		 	cursor.jsonPath = '$.' + cursor.jsonPath
+			cursor.jsonPath = '$.' + cursor.jsonPath
 		}
 
 		const pathArray = JSONPath.toPathArray(cursor.jsonPath!)
-		for (const segment of pathArray) {
-			if (segment !== '$') {
-				this._keys.set(label, segment)
-				break
-			}
-		}
+		this._keys.set(label, pathArray[1])
 	}
 
 	/**


### PR DESCRIPTION
Package jsonpath is impacted by CVE-2026-1615 because of its use of eval()

Following the recommendations for that CVE, let's migrate to jsonpath-plus which offers similar functionality but does not use eval()

Resolves #15 